### PR TITLE
Add customizable tempo and phase settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A new Flutter project.
 
+## Custom experiment configuration
+
+The experiment screen allows adjusting phase durations and induction tempo
+settings from the UI. Use the sliders in the configuration screen to set each
+phase length, the tempo change per step (%) and the number of tempo steps.
+
 ## Getting Started
 
 This project is a starting point for a Flutter application.

--- a/lib/models/experiment_models.dart
+++ b/lib/models/experiment_models.dart
@@ -161,6 +161,12 @@ class ExperimentSession {
   final InductionVariation inductionVariation;
   final Map<AdvancedExperimentPhase, Duration> phaseDurations;
 
+  /// 誘導フェーズでのテンポ変化割合(1ステップあたり)
+  final double inductionStepPercent;
+
+  /// 誘導フェーズのステップ数
+  final int inductionStepCount;
+
   AdvancedExperimentPhase currentPhase;
   DateTime? currentPhaseStartTime;
   double baselineSpm = 0.0;
@@ -177,6 +183,8 @@ class ExperimentSession {
     required this.subjectId,
     this.subjectData = const {},
     this.inductionVariation = InductionVariation.increasing,
+    this.inductionStepPercent = 0.05,
+    this.inductionStepCount = 4,
     Map<AdvancedExperimentPhase, Duration>? customPhaseDurations,
     this.currentPhase = AdvancedExperimentPhase.preparation,
   }) : phaseDurations = customPhaseDurations ??
@@ -251,15 +259,16 @@ class ExperimentSession {
     if (baselineSpm <= 0) return [];
 
     final steps = <double>[];
-    final stepCount = 4; // 5%, 10%, 15%, 20%の4ステップ
+    final stepCount = inductionStepCount;
+    final stepPercent = inductionStepPercent;
 
     if (inductionVariation == InductionVariation.increasing) {
       for (int i = 1; i <= stepCount; i++) {
-        steps.add(baselineSpm * (1 + 0.05 * i));
+        steps.add(baselineSpm * (1 + stepPercent * i));
       }
     } else {
       for (int i = 1; i <= stepCount; i++) {
-        steps.add(baselineSpm * (1 - 0.05 * i));
+        steps.add(baselineSpm * (1 - stepPercent * i));
       }
     }
 

--- a/lib/screens/experiment_screen.dart
+++ b/lib/screens/experiment_screen.dart
@@ -42,6 +42,10 @@ class _ExperimentScreenState extends State<ExperimentScreen> {
   final Map<String, dynamic> _subjectData = {};
   InductionVariation _inductionVariation = InductionVariation.increasing;
 
+  // 誘導フェーズ設定
+  double _inductionStepPercent = 5.0; // %
+  int _inductionStepCount = 4;
+
   // フェーズごとの所要時間（分）
   final Map<AdvancedExperimentPhase, double> _phaseDurationMinutes = {
     AdvancedExperimentPhase.preparation: 5,
@@ -189,6 +193,8 @@ class _ExperimentScreenState extends State<ExperimentScreen> {
       subjectData: _subjectData,
       inductionVariation: _inductionVariation,
       customPhaseDurations: customPhaseDurations,
+      inductionStepPercent: _inductionStepPercent / 100,
+      inductionStepCount: _inductionStepCount,
     );
 
     setState(() {
@@ -413,6 +419,55 @@ class _ExperimentScreenState extends State<ExperimentScreen> {
                 _inductionVariation = value!;
               });
             },
+          ),
+
+          const SizedBox(height: 16),
+
+          const Text(
+            '誘導フェーズ設定',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+
+          ListTile(
+            title: const Text('テンポ変化幅 (1ステップあたり%)'),
+            subtitle:
+                Text('${_inductionStepPercent.toStringAsFixed(1)}%'),
+            trailing: SizedBox(
+              width: 160,
+              child: Slider(
+                value: _inductionStepPercent,
+                min: 1,
+                max: 20,
+                divisions: 19,
+                label: '${_inductionStepPercent.toStringAsFixed(1)}%',
+                onChanged: (value) {
+                  setState(() {
+                    _inductionStepPercent = value;
+                  });
+                },
+              ),
+            ),
+          ),
+
+          ListTile(
+            title: const Text('ステップ数'),
+            subtitle: Text(_inductionStepCount.toString()),
+            trailing: SizedBox(
+              width: 160,
+              child: Slider(
+                value: _inductionStepCount.toDouble(),
+                min: 1,
+                max: 10,
+                divisions: 9,
+                label: _inductionStepCount.toString(),
+                onChanged: (value) {
+                  setState(() {
+                    _inductionStepCount = value.round();
+                  });
+                },
+              ),
+            ),
           ),
 
           const SizedBox(height: 16),

--- a/lib/services/experiment_controller.dart
+++ b/lib/services/experiment_controller.dart
@@ -79,6 +79,8 @@ class ExperimentController {
     Map<String, dynamic>? subjectData,
     InductionVariation inductionVariation = InductionVariation.increasing,
     Map<AdvancedExperimentPhase, Duration>? customPhaseDurations,
+    double inductionStepPercent = 0.05,
+    int inductionStepCount = 4,
   }) async {
     // 前のセッションがあれば停止
     await stopExperiment();
@@ -94,6 +96,8 @@ class ExperimentController {
       subjectData: subjectData ?? {},
       inductionVariation: inductionVariation,
       customPhaseDurations: customPhaseDurations,
+      inductionStepPercent: inductionStepPercent,
+      inductionStepCount: inductionStepCount,
     );
 
     _sendMessage('実験を開始しました: ${condition.name}');


### PR DESCRIPTION
## Summary
- support configurable tempo step percent and step count
- expose new sliders in the experiment setup screen
- document custom experiment configuration in README

## Testing
- `flutter format` *(fails: command not found)*