### PR TITLE
Add smartphone sensor option

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   vibration: ^3.1.3
   flutter_background_service: ^5.1.0
   flutter_local_notifications: ^19.1.0
+  sensors_plus: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add sensors_plus dependency
- allow choosing smartphone sensor or M5Stack at startup
- create accelerometer stream for phone sensor
- show sensor choice status in UI

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*